### PR TITLE
chore: add mise.toml for tool version management

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+pre-commit = "latest"


### PR DESCRIPTION
## Summary

Add `mise.toml` configuration file so that `mise install` works as documented in the README.

## Motivation and Context

The README references `mise install` for setting up project tools (pre-commit), but the `mise.toml` file was missing from the repo. This caused the documented setup flow to fail.

## Changes

- Added `mise.toml` with `pre-commit` as a managed tool

## How to Test

1. Install mise: `winget install jdx.mise` (or `curl https://mise.run | sh` on macOS/Linux)
2. Run `mise trust` then `mise install` in the repo root
3. Verify pre-commit is installed: `mise exec -- pre-commit --version`

## Checklist

- [x] The PR title and description are clear and descriptive.
- [x] I have tested these changes thoroughly.
- [x] The code follows the project's coding guidelines.
- [x] I have added necessary documentation and updated the existing one if required.
- [x] All new and existing tests pass successfully.
- [x] The commit messages are clear and follow the project's commit message conventions.

## Additional Notes (if any)

Pre-commit hooks also block direct commits to `main` via the `no-commit-to-branch` hook.