### PR TITLE
Integrate Chargebee quote automation into scripts/

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,7 @@ CHARGEBEE_SITE=
 
 # SERP API
 SERPAPI_KEY=
+
+# Chargebee Quote Automation (Selenium)
+# Path to a Firefox profile already logged in to Salesforce via SSO (about:profiles)
+FIREFOX_PROFILE_PATH=

--- a/README.md
+++ b/README.md
@@ -11,8 +11,11 @@ salesforce-data-utils/
 ├── requirements.txt      # Python dependencies
 ├── data/                 # Output data (CSVs, gitignored)
 └── scripts/              # All scripts and tools
-    └── serp-api/         # Google Maps enrichment for SF Accounts
+    ├── serp-api/                    # Google Maps enrichment for SF Accounts
+    └── chargebee-quote-automation/  # Selenium UI automation for Chargebee quotes
 ```
+
+See [scripts/README.md](scripts/README.md) for the full, up-to-date list of scripts.
 
 ## Development Setup
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ requests==2.32.5
 fuzzywuzzy==0.18.0
 python-Levenshtein==0.27.3
 pandas>=2.2
+selenium==4.18.1

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,10 +7,12 @@ This folder contains one-shot or job-like scripts that modify Salesforce data, p
 | Folder | Description | README |
 |--------|-------------|--------|
 | `serp-api/` | Enriches Salesforce Accounts with Google Maps data (rating, reviews, price, type, website) via SerpApi | [README](serp-api/README.md) |
+| `chargebee-quote-automation/` | Drives Firefox (Salesforce Classic) to generate Chargebee quote PDFs and sync quotes to opportunities for a CSV of quote IDs | [README](chargebee-quote-automation/README.md) |
 
 ## Conventions
 
-- **File naming**: `job-descriptive-name.(py|sh|js)` or `YYYYMMDD_job-descriptive-name.(py|sh|js)` for dated scripts.
+- **Folder per tool**: each multi-file tool lives in its own kebab-case folder with a `main.py` entry point and a per-tool `README.md`.
+- **File naming**: `job-descriptive-name.(py|sh|js)` or `YYYYMMDD_job-descriptive-name.(py|sh|js)` for dated standalone scripts.
 - Keep scripts idempotent where possible and document side effects in a per-script README.
 - **Credentials**: store secrets in the root `.env` file (gitignored); never commit keys.
 - **Logging**: write logs to stdout; exit non-zero on failure so CI/job schedulers detect errors.

--- a/scripts/chargebee-quote-automation/README.md
+++ b/scripts/chargebee-quote-automation/README.md
@@ -1,0 +1,111 @@
+# Chargebee Quote Automation (Selenium)
+
+This tool automates two Chargebee quote actions in Salesforce **Classic** for the
+platform migration project: **Generate Quote PDF** and **Sync to Opportunity**.
+It reads a CSV of quote identifiers, resolves each record via the Salesforce API,
+then drives Firefox to click the buttons that have no API equivalent.
+
+Originally a standalone repository (`salesforce-click-automation`), it has been
+refactored into this repo's modular layout and now uses `simple-salesforce`
+(shared with the rest of the repo) instead of the internal `pyzenchef` package.
+
+## Logic Overview
+
+1. **Read**: Loads quote identifiers from the CSV column (`--id-column`, default `Name`).
+2. **Resolve**: For each identifier, queries `chargebeeapps__CB_Quote__c` to get the
+   record `Id` and the fields used by the optimized re-run check.
+   - Identifiers starting with `ZCQUO-` are matched on `Name`; otherwise on `Id`.
+3. **Automate**: Navigates Firefox (already logged in via SSO) to each record and clicks:
+   - **Generate Quote PDF** → confirm.
+   - **Sync to Opportunity** → confirm.
+4. **Resume**: On failure, re-run with `--start-from <index>` to continue from the last
+   successful record, or use `--optimized` to skip actions already completed.
+
+## Directory Structure
+
+```text
+salesforce-data-utils/
+├── .env                        # Credentials (gitignored, at repo root)
+├── requirements.txt            # Python dependencies
+└── scripts/
+    └── chargebee-quote-automation/
+        ├── main.py                 # Entry point & orchestration
+        ├── config.py               # Config & Salesforce auth
+        ├── salesforce_client.py    # Salesforce quote lookups (read-only)
+        └── browser_automation.py   # Selenium/Firefox UI actions
+```
+
+## Prerequisites
+
+1. **Install dependencies** (from repo root):
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. **Install Firefox** — [download here](https://www.mozilla.org/en-US/firefox/new/).
+3. **Log in to Salesforce** in Firefox via SSO.
+4. **Switch Salesforce to Classic** — the targeted buttons do **not** exist in
+   Lightning Experience; the script will not work there.
+5. **Find your Firefox profile path** — open `about:profiles`, copy the active
+   profile's "Root Directory".
+
+## Configuration
+
+Set the following in the repo-root `.env` (see `.env.example`):
+
+```env
+# Salesforce (shared across the repo)
+SF_USERNAME=your_username
+SF_PASSWORD=your_password
+SF_TOKEN=your_security_token
+
+# Firefox profile already logged in to Salesforce via SSO
+FIREFOX_PROFILE_PATH=/path/to/Firefox/Profiles/xxxx.default-release
+```
+
+The Salesforce instance URL is derived automatically from the API session, so no
+hostname needs to be configured.
+
+## Usage
+
+All commands are run from the repo root.
+
+### Full run
+```bash
+python scripts/chargebee-quote-automation/main.py --csv data/quotes.csv
+```
+
+### Custom identifier column
+```bash
+python scripts/chargebee-quote-automation/main.py --csv data/quotes.csv --id-column QuoteId
+```
+
+### Resume after a failure
+Re-run starting from the last successfully processed row index:
+```bash
+python scripts/chargebee-quote-automation/main.py --csv data/quotes.csv --start-from 300
+```
+
+### Optimized re-run
+Skip actions that already completed (PDF link present, opportunity already synced):
+```bash
+python scripts/chargebee-quote-automation/main.py --csv data/quotes.csv --optimized
+```
+
+## CLI Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--csv` | *(required)* | Path to the CSV of quote identifiers |
+| `--id-column` | `Name` | CSV column holding the quote Name or record Id |
+| `--start-from` | `0` | Row index to resume from after a failure |
+| `--optimized` | off | Skip actions already completed for a record |
+
+## Troubleshooting
+
+**Issue**: Buttons are never found / timeouts.
+**Solution**: Confirm Salesforce is in **Classic** mode and the Firefox profile is
+logged in via SSO.
+
+**Issue**: The run stops partway through.
+**Solution**: Note the last `RECORD <index>` logged, then re-run with
+`--start-from <index>`. For large batches, `--optimized` avoids redoing finished work.

--- a/scripts/chargebee-quote-automation/browser_automation.py
+++ b/scripts/chargebee-quote-automation/browser_automation.py
@@ -1,0 +1,92 @@
+import logging
+from typing import Any, Dict
+
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+
+logger = logging.getLogger(__name__)
+
+# Default time (seconds) to wait for a clickable element before giving up.
+DEFAULT_WAIT = 20
+
+
+class QuoteBrowserAutomation:
+    """Drives Firefox (Salesforce Classic) to run quote actions via UI clicks.
+
+    Relies on a Firefox profile that is already logged in to Salesforce through
+    SSO, so no credentials are entered here. Salesforce must be in Classic mode;
+    the targeted buttons do not exist in Lightning Experience.
+    """
+
+    def __init__(self, instance_url: str, firefox_profile_path: str, wait: int = DEFAULT_WAIT):
+        self.instance_url = instance_url.rstrip("/")
+        self.wait = wait
+
+        options = webdriver.FirefoxOptions()
+        options.add_argument("-profile")
+        options.add_argument(firefox_profile_path)
+        self.driver = webdriver.Firefox(options=options)
+
+    def _record_url(self, record_id: str) -> str:
+        return f"{self.instance_url}/{record_id}"
+
+    def open_record(self, record_id: str):
+        self.driver.get(self._record_url(record_id))
+
+    def dismiss_first_visit_prompt(self):
+        """Click the Classic landing/confirmation button shown on first navigation."""
+        self.driver.find_element(
+            By.CLASS_NAME, "button.button.mb12.secondary.wide"
+        ).click()
+
+    def click_generate_pdf(self):
+        generate_pdf_button = WebDriverWait(self.driver, self.wait).until(
+            EC.element_to_be_clickable((By.NAME, "chargebeeapps__generate_quote_pdf"))
+        )
+        generate_pdf_button.click()
+
+        confirm_button = WebDriverWait(self.driver, self.wait).until(
+            EC.element_to_be_clickable((By.CLASS_NAME, "slds-button.slds-button_brand"))
+        )
+        confirm_button.click()
+
+    def click_sync_to_opportunity(self):
+        sync_button = WebDriverWait(self.driver, self.wait).until(
+            EC.element_to_be_clickable((By.NAME, "chargebeeapps__sync_to_opportunity"))
+        )
+        sync_button.click()
+
+        confirm_sync_button = WebDriverWait(self.driver, self.wait).until(
+            EC.element_to_be_clickable((By.NAME, "j_id0:theform:SyncToOpportunityBtn"))
+        )
+        confirm_sync_button.click()
+
+    def run_actions(self, record: Dict[str, Any]):
+        """Generate the quote PDF, then sync the quote to its opportunity."""
+        record_id = record["Id"]
+        self.open_record(record_id)
+        self.click_generate_pdf()
+        self.open_record(record_id)
+        self.click_sync_to_opportunity()
+
+    def run_actions_optimized(self, record: Dict[str, Any]):
+        """Only run the actions that have not already completed for this record.
+
+        Slower per record than run_actions() because it inspects state, but it
+        avoids redoing work when re-running over a partially processed batch.
+        """
+        record_id = record["Id"]
+        opportunity = record.get("chargebeeapps__Opportunity__r") or {}
+
+        if record.get("chargebeeapps__CB_Acceptance_Link__c") is None:
+            self.open_record(record_id)
+            self.click_generate_pdf()
+
+        if opportunity.get("Count_Opportunity_Products__c") == 0:
+            self.open_record(record_id)
+            self.click_sync_to_opportunity()
+
+    def quit(self):
+        self.driver.quit()

--- a/scripts/chargebee-quote-automation/config.py
+++ b/scripts/chargebee-quote-automation/config.py
@@ -1,0 +1,44 @@
+import os
+from pathlib import Path
+from simple_salesforce import Salesforce
+from dotenv import load_dotenv
+
+# Load .env from repo root (two levels up from scripts/chargebee-quote-automation/)
+_root = Path(__file__).resolve().parent.parent.parent
+load_dotenv(_root / '.env')
+
+# Salesforce Credentials (shared with the rest of the repo)
+SF_USERNAME = os.getenv("SF_USERNAME")
+SF_PASSWORD = os.getenv("SF_PASSWORD")
+SF_TOKEN = os.getenv("SF_TOKEN")
+
+# Path to the Firefox profile that is already logged in to Salesforce via SSO.
+# Find it at about:profiles -> active profile -> "Root Directory".
+FIREFOX_PROFILE_PATH = os.getenv("FIREFOX_PROFILE_PATH")
+
+
+def get_salesforce_client() -> Salesforce:
+    """Returns an authenticated Salesforce client using standard auth."""
+    return Salesforce(
+        username=SF_USERNAME,
+        password=SF_PASSWORD,
+        security_token=SF_TOKEN
+    )
+
+
+def validate_config():
+    """Validates that necessary environment variables are set."""
+    missing = []
+
+    if not all([SF_USERNAME, SF_PASSWORD, SF_TOKEN]):
+        missing.append("Salesforce Credentials (SF_USERNAME, SF_PASSWORD, SF_TOKEN)")
+
+    if not FIREFOX_PROFILE_PATH:
+        missing.append("FIREFOX_PROFILE_PATH")
+
+    if missing:
+        raise ValueError(f"Missing required configuration: {', '.join(missing)}")
+
+
+# Validate on import
+validate_config()

--- a/scripts/chargebee-quote-automation/main.py
+++ b/scripts/chargebee-quote-automation/main.py
@@ -1,0 +1,86 @@
+import argparse
+import logging
+import sys
+
+import pandas as pd
+
+from config import FIREFOX_PROFILE_PATH, get_salesforce_client
+from salesforce_client import QuoteSalesforceClient
+from browser_automation import QuoteBrowserAutomation
+
+# Configure Logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s',
+    handlers=[logging.StreamHandler(sys.stdout)]
+)
+logger = logging.getLogger(__name__)
+
+
+def resolve_filter_field(sample_id: str) -> str:
+    """Chargebee quote names start with 'ZCQUO-'; everything else is a record Id."""
+    return "Name" if "ZCQUO-" in str(sample_id) else "Id"
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate quote PDFs and sync quotes to opportunities via the Salesforce Classic UI."
+    )
+    parser.add_argument("--csv", required=True, help="Path to the CSV file containing quote identifiers")
+    parser.add_argument("--id-column", default="Name", help="CSV column holding the quote Name or Id (default: Name)")
+    parser.add_argument("--start-from", type=int, default=0,
+                        help="Row index to resume from after a failure (default: 0)")
+    parser.add_argument("--optimized", action="store_true",
+                        help="Skip actions already completed for a record (use when re-running a batch)")
+    args = parser.parse_args()
+
+    df = pd.read_csv(args.csv)
+    if args.id_column not in df.columns:
+        logger.error(f"Column '{args.id_column}' not found in {args.csv}. Available: {list(df.columns)}")
+        return
+
+    quote_ids = df[args.id_column].tolist()
+    if not quote_ids:
+        logger.info("No quote identifiers found in the CSV.")
+        return
+
+    filter_field = resolve_filter_field(quote_ids[0])
+    logger.info(f"Processing {len(quote_ids)} quotes by '{filter_field}' (optimized: {args.optimized}).")
+
+    sf = get_salesforce_client()
+    sf_client = QuoteSalesforceClient(sf)
+    browser = QuoteBrowserAutomation(sf_client.instance_url, FIREFOX_PROFILE_PATH)
+
+    try:
+        for i, quote_id in enumerate(quote_ids):
+            if i < args.start_from:
+                continue
+
+            logger.info(f"=== RECORD {i}: {quote_id}")
+
+            record = sf_client.get_quote_record(quote_id, filter_field)
+            if not record:
+                logger.warning(f"No quote found for {quote_id}; skipping.")
+                continue
+
+            # On the very first navigation, dismiss the Classic landing prompt.
+            browser.open_record(record["Id"])
+            if i == args.start_from:
+                browser.dismiss_first_visit_prompt()
+
+            if args.optimized:
+                browser.run_actions_optimized(record)
+            else:
+                browser.run_actions(record)
+
+        logger.info("Finished processing all quotes.")
+    except Exception as e:
+        logger.error(f"Run stopped at an error: {e}")
+        logger.error("Re-run with --start-from <last successful record index> to resume.")
+        raise
+    finally:
+        browser.quit()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/chargebee-quote-automation/salesforce_client.py
+++ b/scripts/chargebee-quote-automation/salesforce_client.py
@@ -1,0 +1,46 @@
+import logging
+from typing import Any, Dict, Optional
+from simple_salesforce import Salesforce
+from requests.exceptions import RequestException
+
+logger = logging.getLogger(__name__)
+
+
+class QuoteSalesforceClient:
+    """Read-only Salesforce client used to resolve Chargebee quote records.
+
+    The browser automation only needs each quote's record Id (to navigate to it)
+    plus a couple of fields used to decide whether an action still needs to run.
+    """
+
+    def __init__(self, sf: Salesforce):
+        self.sf = sf
+
+    @property
+    def instance_url(self) -> str:
+        """Base instance URL, e.g. https://zenchef.my.salesforce.com."""
+        return f"https://{self.sf.sf_instance}"
+
+    def get_quote_record(self, quote_id: str, filter_field: str) -> Optional[Dict[str, Any]]:
+        """Fetch a single Chargebee quote record by Name or Id.
+
+        Returns the record dict (or None if not found). Fields mirror the
+        original automation so the optimized re-run logic keeps working.
+        """
+        soql = (
+            "SELECT "
+            "Id, "
+            "chargebeeapps__CB_Acceptance_Link__c, "
+            "chargebeeapps__Opportunity__r.chargebeeapps__Payment_Link__c, "
+            "chargebeeapps__Opportunity__r.Count_Opportunity_Products__c "
+            "FROM chargebeeapps__CB_Quote__c "
+            f"WHERE {filter_field} = '{quote_id}'"
+        )
+
+        try:
+            results = self.sf.query(soql)
+            records = results.get("records", [])
+            return records[0] if records else None
+        except RequestException as e:
+            logger.error(f"Error fetching quote {quote_id}: {e}")
+            return None


### PR DESCRIPTION
## What

Moves the standalone `salesforce-click-automation` project into this repo at `scripts/chargebee-quote-automation/`, refactored to match the existing `serp-api/` modular layout so it's seamlessly integrated.

## Changes

- **New tool** `scripts/chargebee-quote-automation/` split into clean modules:
  - `config.py` — env loading + Salesforce auth (matches serp-api)
  - `salesforce_client.py` — read-only quote lookups
  - `browser_automation.py` — Selenium/Firefox UI actions
  - `main.py` — argparse orchestration
  - `README.md` — full usage docs
- **Dropped `pyzenchef`** (heavy internal dep) in favor of `simple-salesforce`, already used repo-wide. Instance URL is now derived from the API session instead of a hardcoded hostname.
- **Externalized hardcoded values** into CLI args (`--csv`, `--id-column`, `--start-from`, `--optimized`) and `.env` (`FIREFOX_PROFILE_PATH`).
- **Repo wiring**: added `selenium` to `requirements.txt`, `FIREFOX_PROFILE_PATH` to `.env.example`, and listed the tool in both `scripts/README.md` and the root `README.md`.

## Notes

Behaviour (selectors, click sequence, ZCQUO-/Id filter, resume-from-N, optimized re-run) is preserved from the original. Browser automation requires Firefox logged in via SSO + Salesforce Classic; not runnable in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)